### PR TITLE
Feat: 初期処理の構築

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+output/
 parts/
 sdist/
 var/

--- a/InitSetup.sh
+++ b/InitSetup.sh
@@ -1,0 +1,71 @@
+#!/bin/bash -xeu
+
+# 前提：gitとbash,sudoが利用できる環境が条件
+#       zsh, cshなどは想定外
+
+readonly RC_NORMAL=0
+readonly RC_ERROR=1
+
+PYENV_GIT_URL="https://github.com/pyenv/pyenv.git"
+CLONE_ROOT_PATH="/opt"
+PYENV_ROOT_PATH="${CLONE_ROOT_PATH}/pyenv"
+BASH_PROFILE_FILE="${HOME}/.bash_profile"
+INSTALL_PYTHON_VERSION="3.9.1"
+
+function CheckUseSudoCommand() {
+  set +e
+  sudo -l >> /dev/null 2>&1
+  isPrivilegedRoot=$?
+  
+  if [[ "${isPrivilegedRoot}" != ${RC_NORMAL} ]]
+  then
+    echo "このスクリプトは利用できません。特権権限に昇格できるユーザで実行してください。"
+    exit ${RC_ERROR}
+  fi
+  set -e
+  
+  return ${RC_NORMAL}
+}
+
+function SetupPyenv() {
+  if [[ -d "${PYENV_ROOT_PATH}" ]]
+  then
+    return ${RC_NORMAL}
+  fi
+  
+  pushd ${CLONE_ROOT_PATH}
+  sudo git clone ${PYENV_GIT_URL}
+  sudo chown -R $(whoami): ${PYENV_ROOT_PATH}
+  popd
+  
+  return ${RC_NORMAL}
+}
+
+function SetupPyenvConfiguration() {
+  if [[ "$(egrep '^which pyenv' ${BASH_PROFILE_FILE})" == "" ]]
+  then
+    echo 'which pyenv >> /dev/null 2>&1 && eval "$(pyenv init -)"' >> ${BASH_PROFILE_FILE}
+  fi
+  
+  source ${BASH_PROFILE_FILE}
+  
+  return ${RC_NORMAL}
+}
+
+# 事前実行条件調査
+CheckUseSudoCommand
+
+# 環境のセットアップ
+SetupPyenv
+# SetupPyenvConfiguration
+
+# 構築調査
+which pyenv
+
+export PIPENV_VENV_IN_PROJECT=true
+yes Y | pipenv --python ${INSTALL_PYTHON_VERSION}
+
+curl -kL https://bootstrap.pypa.io/get-pip.py | python
+pipenv sync
+
+exit ${RC_NORMAL}

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+matplotlib = "==3.5.0"
+numpy = "==1.22.0"
+pillow = "==8.4.0"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,258 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "024e8e475fc0c0041340efc87eb272040835850d660ca272ff74ca1c0975125c"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "cycler": {
+            "hashes": [
+                "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3",
+                "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.11.0"
+        },
+        "fonttools": {
+            "hashes": [
+                "sha256:236b29aee6b113e8f7bee28779c1230a86ad2aac9a74a31b0aedf57e7dfb62a4",
+                "sha256:2df636a3f402ef14593c6811dac0609563b8c374bd7850e76919eb51ea205426"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.31.2"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:139c75216e5875ee5f8f4f7adcc3cd339f46f0d66bda2e10d8d21386d635476f",
+                "sha256:14f43edc25daa0646d4b4e86c2ebdd32d785ab73a65a570130a3d234a4554b07",
+                "sha256:17ec8bd4e162fd0a8723467395c5bb16fd665a528b78e9339886c82965ed8efb",
+                "sha256:199f32bf6f3d3e2246024326497513c5c49c62aecee86f0ac019f5991978d505",
+                "sha256:1cf8c81e8a5fb4f5dcbd473fdb619b895313d29b7c60e4545827dcc6efbd8efc",
+                "sha256:2467fe5fff6ed2a728e10dca9b1f37e9b911ca5b228a7d8990c8e3abf80c1724",
+                "sha256:313724e85fd14d581a939fa02424f4dc772fd914bc04499a8a6377d47313b966",
+                "sha256:334a7e3d498a0a791245f0964c746d0414e9b13aef73237f0d798a2101fdbae9",
+                "sha256:34e2e39a219b203fa3a82af5b9f8d386a8718677de7a9b82a9634e292a8f4e0a",
+                "sha256:384b5076b2c0172003abca9ba8b8c5efcaaffd31616f3f5e0a09dcc34772d012",
+                "sha256:3891527ec51b0365bb50de9bf826ce3d5b1adc276685b2779889762437bbd359",
+                "sha256:38ebc0cb30ed2f59bd15e23591a53698005123e90e880f1af4600fcdbe4912e1",
+                "sha256:4471a48f53d20d49f263ca888aab77b754525ef35e6767657e1a44a724a8b0af",
+                "sha256:4b70f0729947d6327cd659e1b3477ced44a317a4ba441238b2a3642990f0ebd7",
+                "sha256:576ba51b9f4e4d0d583c1cd257f53397bdc5e66a5e49fe68712f658426115777",
+                "sha256:5ca92de8e48678a2cbbd90adb10773e3553bb9fd1c090bf0dfe5fc3337a181ea",
+                "sha256:5ecf82bb25cec7df4bfcf37afe49f6f6202b4fa4029be7cb0848ed319c72d356",
+                "sha256:65cbdbe14dc5988e362eb15e02dd24c6724238cb235132f812f1e3a29a61a3de",
+                "sha256:676f9fac93f97f529dc80b5d6731099fad337549408e8bdd929343b7cb679797",
+                "sha256:6bf0080449d6ea39b817d85abd2c20d2d42fd9b1587544d64371d28d93c379cf",
+                "sha256:6c19457f58941da61681efaabd5b1c37893108a2f922b9b19538f6921911186d",
+                "sha256:70e7b7a4ebeddef423115ea31857732fc04e0f38dd1e6385e1af05b6164a3d0f",
+                "sha256:71d44a6a59ea53d41e5950a42ec496fa821bd86f292fb3e10aa1b3932ecfc65e",
+                "sha256:734e943ae519cdb8534d9053f478417c525ec921c06896ec7119e65d9ea4a687",
+                "sha256:7508b01e211178a85d21f1f87029846b77b2404a4c68cbd14748d4d4142fa3b8",
+                "sha256:87367ba1ad3819f7189fe8faff5f75a7603f526576033e7b86e10b598f8790b2",
+                "sha256:895b2df026006ff7434b03ca495983d0d26da96f6d58414c77d616747ee77e34",
+                "sha256:8cd1f81bc35ec24cb82a7d0b805521e3d71b25b8a493d5810d18dc29644c6ef8",
+                "sha256:8f63b981678ca894bb665bcd5043bde2c9ba600e69df730c1ceeadd73ddbcb8c",
+                "sha256:925a32900fc16430ba0dec2c0fca2e776eaf2fdc0930d5552be0a59e23304001",
+                "sha256:97372c837add54e3e64a811464b14bb01428c4e9256072b6296f04157ea23246",
+                "sha256:9b4d1db32a4f1682df1480fd68eb1400235ac8f9ad8932e1624fdb23eb891904",
+                "sha256:a0a6f3d5063e7fd6662e4773778ad2cb36e598abc6eb171af4a072ca86b441d0",
+                "sha256:af6a7c956a45ee721e4263f5823e1a3b2e6b21a7e2b3646b3794e000620609d0",
+                "sha256:b1ff5582bf55e85728119c5a23f695b8e408e15eee7d0f5effe0ee8ad1f8b523",
+                "sha256:bb997d1631b20745b18674d68dd6f1d9d45db512efd5fe0f162a5d4a6bbdd211",
+                "sha256:c29496625c61e18d97a6f6c2f2a55759ca8290fc21a751bc57824599c431c0d2",
+                "sha256:caff7ae6fb6dce2f520b2d46efc801605fa1378fb19bb4580aebc6174eab05a0",
+                "sha256:cbf9aa926de224af15c974750fecdc7d2c0043428372acaaf61216e202abbf21",
+                "sha256:cd0223a3a4ddcc0d0e06c6cfeb0adde2bc19c08b4c7fc79d48dac2486a4b115b",
+                "sha256:daf2030bf18c21bf91fa9cf6a403a765519c9168bd7a91ba1d66d5c7f70ded1e",
+                "sha256:ed30c5e58e578a2981c67346b2569e04120d1b80fa6906c207fe824d24603313",
+                "sha256:ed937691f522cc2362c280c903837a4e35195659b9935b598e3cd448db863605"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.4.0"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:0abf8b51cc6d3ba34d1b15b26e329f23879848a0cf1216954c1f432ffc7e1af7",
+                "sha256:0e020a42f3338823a393dd2f80e39a2c07b9f941dfe2c778eb104eeb33d60bb5",
+                "sha256:13930a0c9bec0fd25f43c448b047a21af1353328b946f044a8fc3be077c6b1a8",
+                "sha256:153a0cf6a6ff4f406a0600d2034710c49988bacc6313d193b32716f98a697580",
+                "sha256:18f6e52386300db5cc4d1e9019ad9da2e80658bab018834d963ebb0aa5355095",
+                "sha256:2089b9014792dcc87bb1d620cde847913338abf7d957ef05587382b0cb76d44e",
+                "sha256:2eea16883aa7724c95eea0eb473ab585c6cf66f0e28f7f13e63deb38f4fd6d0f",
+                "sha256:38892a254420d95594285077276162a5e9e9c30b6da08bdc2a4d53331ad9a6fa",
+                "sha256:4b018ea6f26424a0852eb60eb406420d9f0d34f65736ea7bbfbb104946a66d86",
+                "sha256:65f877882b7ddede7090c7d87be27a0f4720fe7fc6fddd4409c06e1aa0f1ae8d",
+                "sha256:666d717a4798eb9c5d3ae83fe80c7bc6ed696b93e879cb01cb24a74155c73612",
+                "sha256:66b172610db0ececebebb09d146f54205f87c7b841454e408fba854764f91bdd",
+                "sha256:6db02c5605f063b67780f4d5753476b6a4944343284aa4e93c5e8ff6e9ec7f76",
+                "sha256:6e0e6b2111165522ad336705499b1f968c34a9e84d05d498ee5af0b5697d1efe",
+                "sha256:71a1851111f23f82fc43d2b6b2bfdd3f760579a664ebc939576fe21cc6133d01",
+                "sha256:7a7cb59ebd63a8ac4542ec1c61dd08724f82ec3aa7bb6b4b9e212d43c611ce3d",
+                "sha256:7baf23adb698d8c6ca7339c9dde00931bc47b2dd82fa912827fef9f93db77f5e",
+                "sha256:970aa97297537540369d05fe0fd1bb952593f9ab696c9b427c06990a83e2418b",
+                "sha256:9bac8eb1eccef540d7f4e844b6313d9f7722efd48c07e1b4bfec1056132127fd",
+                "sha256:a07ff2565da72a7b384a9e000b15b6b8270d81370af8a3531a16f6fbcee023cc",
+                "sha256:a0dcaf5648cecddc328e81a0421821a1f65a1d517b20746c94a1f0f5c36fb51a",
+                "sha256:a0ea10faa3bab0714d3a19c7e0921279a68d57552414d6eceaea99f97d7735db",
+                "sha256:a5b62d1805cc83d755972033c05cea78a1e177a159fc84da5c9c4ab6303ccbd9",
+                "sha256:a6cef5b31e27c31253c0f852b629a38d550ae66ec6850129c49d872f9ee428cb",
+                "sha256:a7bf8b05c214d32fb7ca7c001fde70b9b426378e897b0adbf77b85ea3569d56a",
+                "sha256:ac17a7e7b06ee426a4989f0b7f24ab1a592e39cdf56353a90f4e998bc0bf44d6",
+                "sha256:b3b687e905da32e5f2e5f16efa713f5d1fcd9fb8b8c697895de35c91fedeb086",
+                "sha256:b5e439d9e55d645f2a4dca63e2f66d68fe974c405053b132d61c7e98c25dfeb2",
+                "sha256:ba107add08e12600b072cf3c47aaa1ab85dd4d3c48107a5d3377d1bf80f8b235",
+                "sha256:d092b7ba63182d2dd427904e3eb58dd5c46ec67c5968de14a4b5007010a3a4cc",
+                "sha256:dc8c5c23e7056e126275dbf29efba817b3d94196690930d0968873ac3a94ab82",
+                "sha256:df0042cab69f4d246f4cb8fc297770ac4ae6ec2983f61836b04a117722037dcd",
+                "sha256:ee3d9ff16d749a9aa521bd7d86f0dbf256b2d2ac8ce31b19e4d2c86d2f2ff0b6",
+                "sha256:f23fbf70d2e80f4e03a83fc1206a8306d9bc50482fee4239f10676ce7e470c83",
+                "sha256:ff5d9fe518ad2de14ce82ab906b6ab5c2b0c7f4f984400ff8a7a905daa580a0a"
+            ],
+            "index": "pypi",
+            "version": "==3.5.0"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:0cfe07133fd00b27edee5e6385e333e9eeb010607e8a46e1cd673f05f8596595",
+                "sha256:11a1f3816ea82eed4178102c56281782690ab5993251fdfd75039aad4d20385f",
+                "sha256:2762331de395739c91f1abb88041f94a080cb1143aeec791b3b223976228af3f",
+                "sha256:283d9de87c0133ef98f93dfc09fad3fb382f2a15580de75c02b5bb36a5a159a5",
+                "sha256:3d22662b4b10112c545c91a0741f2436f8ca979ab3d69d03d19322aa970f9695",
+                "sha256:41388e32e40b41dd56eb37fcaa7488b2b47b0adf77c66154d6b89622c110dfe9",
+                "sha256:42c16cec1c8cf2728f1d539bd55aaa9d6bb48a7de2f41eb944697293ef65a559",
+                "sha256:47ee7a839f5885bc0c63a74aabb91f6f40d7d7b639253768c4199b37aede7982",
+                "sha256:5a311ee4d983c487a0ab546708edbdd759393a3dc9cd30305170149fedd23c88",
+                "sha256:5dc65644f75a4c2970f21394ad8bea1a844104f0fe01f278631be1c7eae27226",
+                "sha256:6ed0d073a9c54ac40c41a9c2d53fcc3d4d4ed607670b9e7b0de1ba13b4cbfe6f",
+                "sha256:76ba7c40e80f9dc815c5e896330700fd6e20814e69da9c1267d65a4d051080f1",
+                "sha256:818b9be7900e8dc23e013a92779135623476f44a0de58b40c32a15368c01d471",
+                "sha256:a024181d7aef0004d76fb3bce2a4c9f2e67a609a9e2a6ff2571d30e9976aa383",
+                "sha256:a955e4128ac36797aaffd49ab44ec74a71c11d6938df83b1285492d277db5397",
+                "sha256:a97a954a8c2f046d3817c2bce16e3c7e9a9c2afffaf0400f5c16df5172a67c9c",
+                "sha256:a97e82c39d9856fe7d4f9b86d8a1e66eff99cf3a8b7ba48202f659703d27c46f",
+                "sha256:b55b953a1bdb465f4dc181758570d321db4ac23005f90ffd2b434cc6609a63dd",
+                "sha256:bb02929b0d6bfab4c48a79bd805bd7419114606947ec8284476167415171f55b",
+                "sha256:bece0a4a49e60e472a6d1f70ac6cdea00f9ab80ff01132f96bd970cdd8a9e5a9",
+                "sha256:e41e8951749c4b5c9a2dc5fdbc1a4eec6ab2a140fdae9b460b0f557eed870f4d",
+                "sha256:f71d57cc8645f14816ae249407d309be250ad8de93ef61d9709b45a0ddf4050c"
+            ],
+            "index": "pypi",
+            "version": "==1.22.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:066f3999cb3b070a95c3652712cffa1a748cd02d60ad7b4e485c3748a04d9d76",
+                "sha256:0a0956fdc5defc34462bb1c765ee88d933239f9a94bc37d132004775241a7585",
+                "sha256:0b052a619a8bfcf26bd8b3f48f45283f9e977890263e4571f2393ed8898d331b",
+                "sha256:1394a6ad5abc838c5cd8a92c5a07535648cdf6d09e8e2d6df916dfa9ea86ead8",
+                "sha256:1bc723b434fbc4ab50bb68e11e93ce5fb69866ad621e3c2c9bdb0cd70e345f55",
+                "sha256:244cf3b97802c34c41905d22810846802a3329ddcb93ccc432870243211c79fc",
+                "sha256:25a49dc2e2f74e65efaa32b153527fc5ac98508d502fa46e74fa4fd678ed6645",
+                "sha256:2e4440b8f00f504ee4b53fe30f4e381aae30b0568193be305256b1462216feff",
+                "sha256:3862b7256046fcd950618ed22d1d60b842e3a40a48236a5498746f21189afbbc",
+                "sha256:3eb1ce5f65908556c2d8685a8f0a6e989d887ec4057326f6c22b24e8a172c66b",
+                "sha256:3f97cfb1e5a392d75dd8b9fd274d205404729923840ca94ca45a0af57e13dbe6",
+                "sha256:493cb4e415f44cd601fcec11c99836f707bb714ab03f5ed46ac25713baf0ff20",
+                "sha256:4acc0985ddf39d1bc969a9220b51d94ed51695d455c228d8ac29fcdb25810e6e",
+                "sha256:5503c86916d27c2e101b7f71c2ae2cddba01a2cf55b8395b0255fd33fa4d1f1a",
+                "sha256:5b7bb9de00197fb4261825c15551adf7605cf14a80badf1761d61e59da347779",
+                "sha256:5e9ac5f66616b87d4da618a20ab0a38324dbe88d8a39b55be8964eb520021e02",
+                "sha256:620582db2a85b2df5f8a82ddeb52116560d7e5e6b055095f04ad828d1b0baa39",
+                "sha256:62cc1afda735a8d109007164714e73771b499768b9bb5afcbbee9d0ff374b43f",
+                "sha256:70ad9e5c6cb9b8487280a02c0ad8a51581dcbbe8484ce058477692a27c151c0a",
+                "sha256:72b9e656e340447f827885b8d7a15fc8c4e68d410dc2297ef6787eec0f0ea409",
+                "sha256:72cbcfd54df6caf85cc35264c77ede902452d6df41166010262374155947460c",
+                "sha256:792e5c12376594bfcb986ebf3855aa4b7c225754e9a9521298e460e92fb4a488",
+                "sha256:7b7017b61bbcdd7f6363aeceb881e23c46583739cb69a3ab39cb384f6ec82e5b",
+                "sha256:81f8d5c81e483a9442d72d182e1fb6dcb9723f289a57e8030811bac9ea3fef8d",
+                "sha256:82aafa8d5eb68c8463b6e9baeb4f19043bb31fefc03eb7b216b51e6a9981ae09",
+                "sha256:84c471a734240653a0ec91dec0996696eea227eafe72a33bd06c92697728046b",
+                "sha256:8c803ac3c28bbc53763e6825746f05cc407b20e4a69d0122e526a582e3b5e153",
+                "sha256:93ce9e955cc95959df98505e4608ad98281fff037350d8c2671c9aa86bcf10a9",
+                "sha256:9a3e5ddc44c14042f0844b8cf7d2cd455f6cc80fd7f5eefbe657292cf601d9ad",
+                "sha256:a4901622493f88b1a29bd30ec1a2f683782e57c3c16a2dbc7f2595ba01f639df",
+                "sha256:a5a4532a12314149d8b4e4ad8ff09dde7427731fcfa5917ff16d0291f13609df",
+                "sha256:b8831cb7332eda5dc89b21a7bce7ef6ad305548820595033a4b03cf3091235ed",
+                "sha256:b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed",
+                "sha256:c70e94281588ef053ae8998039610dbd71bc509e4acbc77ab59d7d2937b10698",
+                "sha256:c8a17b5d948f4ceeceb66384727dde11b240736fddeda54ca740b9b8b1556b29",
+                "sha256:d82cdb63100ef5eedb8391732375e6d05993b765f72cb34311fab92103314649",
+                "sha256:d89363f02658e253dbd171f7c3716a5d340a24ee82d38aab9183f7fdf0cdca49",
+                "sha256:d99ec152570e4196772e7a8e4ba5320d2d27bf22fdf11743dd882936ed64305b",
+                "sha256:ddc4d832a0f0b4c52fff973a0d44b6c99839a9d016fe4e6a1cb8f3eea96479c2",
+                "sha256:e3dacecfbeec9a33e932f00c6cd7996e62f53ad46fbe677577394aaa90ee419a",
+                "sha256:eb9fc393f3c61f9054e1ed26e6fe912c7321af2f41ff49d3f83d05bacf22cc78"
+            ],
+            "index": "pypi",
+            "version": "==8.4.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
+                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.7"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:63b73d83c4d419d9dd992978cf369af5b6efa06236a4a1397b9bdf3ecadb0453",
+                "sha256:9bc2671450c57d9e4885e7dcdc552e3b107b80a5a8f8b1a1df7d06f52db194be"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==61.1.0"
+        },
+        "setuptools-scm": {
+            "hashes": [
+                "sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30",
+                "sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.4.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
+        }
+    },
+    "develop": {}
+}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,234 @@
+# -*- encoding:utf-8 -*-
+
+import sys
+import argparse
+import itertools
+import threading
+import multiprocessing
+import asyncio
+import time
+
+import numpy as np
+import matplotlib.pyplot as plt
+from PIL import Image
+
+""""""
+" 初期化関連処理
+""""""
+is_running_process = True
+is_output_suspend = False
+
+NORMAL_EXIT = 0
+ERROR_EXIT = 1
+
+OUTPUT_DIR = "output"
+COLORS = {
+  "blue": "b",
+  "green": "g",
+  "red": "r",
+  "cyan": "c",
+  "magenta": "m",
+  "yellow": "y",
+  "black": "k",
+  "white": "w"
+}
+DEFAULT_EQUAL_WIDTH_BINS = 255
+
+WINDOW_TITLE_PREFIX = "Figure of "
+WINDOW_TITLE_SUFFIX = " - Normalized"
+
+DEFAULT_FIGURE_TITLE_NAME = "Figure" + WINDOW_TITLE_SUFFIX
+HUE_FIGURE_TITLE_NAME = WINDOW_TITLE_PREFIX + "Hue" + WINDOW_TITLE_SUFFIX
+SATURATION_FIGURE_TITLE_NAME = WINDOW_TITLE_PREFIX + "Saturation" + WINDOW_TITLE_SUFFIX
+BRIGHTNESS_FIGURE_TITLE_NAME = WINDOW_TITLE_PREFIX + "Brightness" + WINDOW_TITLE_SUFFIX
+
+input_file_name = ""
+output_file_name = ""
+equal_width = DEFAULT_EQUAL_WIDTH_BINS 
+is_dny_output = False
+verbosity = 0
+
+NOMAL_MODE = 0
+NOISY_MODE = 1
+VERY_NOISY_MODE = 2
+
+##################################################
+#              デバッグ情報表示用                 
+##################################################
+def PrintDebugInfomation(input_image, hsv_image, hue_image, saturation_image, brightness_image):
+  print("\r", input_image.format, input_image.size, input_image.mode)
+  print(hsv_image.format, hsv_image.size, hsv_image.mode)
+  print("hue object: ", hue_image)
+  print("saturation object: ", saturation_image)
+  print("brightness object: ", brightness_image)
+
+##################################################
+#         実行中のアニメーション表示用                 
+##################################################
+def WaitngAnimate():
+  global is_running_process
+  global is_output_suspend
+  
+  animation_dot = ['       ', '.      ', '..     ', '...    ', '....   ', '...... ']
+  dot_idx = 0
+  dot_len = len(animation_dot) - 1
+  
+  try:
+    for animation_cycle in itertools.cycle(['|', '/', '-', '\\']):
+      if is_running_process == False:
+        break
+      elif is_output_suspend == True:
+        time.sleep(0.1)
+        continue
+      sys.stdout.write('\r['+ animation_cycle + ']: Image analyzer is now in progress' + animation_dot[dot_idx])
+      if dot_idx == dot_len:
+        dot_idx = 0
+      else:
+        dot_idx += 1
+      time.sleep(0.1)
+    sys.stdout.write('\rDone!                                                 ')
+  except Exception as e:
+    print("Unexpected error: " + str(e))
+    sys.exit(ERROR_EXIT)
+  except KeyboardInterrupt:
+    pass
+  
+  sys.exit(NORMAL_EXIT)
+
+##################################################
+#                  引数制御用                
+##################################################
+def DefineSystemArgumentsProcess():
+  global input_file_name
+  global output_file_name
+  global equal_width
+  global is_dny_output
+  global verbosity
+  
+  parser = argparse.ArgumentParser(description="Create a separated HSV parameter image and making these figures.")
+  parser._action_groups.pop()
+  required = parser.add_argument_group('required arguments')
+  optional = parser.add_argument_group('optional arguments')
+  optional.add_argument("-v", "--verbosity", default=0, action="count", help="Increase output verbosity. The value is up to 2.")
+  optional.add_argument("-e", "--equal-width", type=int, default=DEFAULT_EQUAL_WIDTH_BINS, help="Set histogram figures's equal-width bins. The default value is 255.")
+  optional.add_argument("-o", "--output-file", "--output-file-prefix", type=str, default="", help="The prefix result file name.")
+  optional.add_argument("-d", "--is-dny-output", action='store_const', default=False, const=True, help="Deny output to the HSV files.")
+  required.add_argument("-f", "--file", type=str, help="The analyzer target file name.", required=True)
+  args = parser.parse_args()
+  
+  input_file_name = args.file
+  if args.output_file == "":
+    output_file_name = ""
+  else:
+    output_file_name = args.output_file + "_"
+  equal_width = args.equal_width
+  is_dny_output = args.is_dny_output
+  verbosity = args.verbosity 
+  
+  if verbosity == VERY_NOISY_MODE:
+    print(args)
+
+##################################################
+#                  グラフ制御用                 
+##################################################
+def MakePlotFigure(hsv_base_image: Image, figure, plot_color: str, 
+                   figure_title: str, xlabel: str, ylabel: str, equal_width_bins: int,
+                   output_prefix_name: str, output_suffix_name: str):
+  global is_output_suspend
+  global is_dny_output
+  
+  figure_base_data=list(hsv_base_image.getdata())
+  if verbosity == VERY_NOISY_MODE:
+    is_output_suspend = True
+    time.sleep(0.5)
+    print("\r>", output_suffix_name, "                                                ")
+    print("   MAX:", max(figure_base_data), " , min: ", min(figure_base_data))
+    is_output_suspend = False
+  figure.hist(figure_base_data, bins=equal_width_bins, density=True, color=plot_color)
+  figure.set_title(figure_title)
+  figure.set_xlabel(xlabel)
+  figure.set_ylabel(ylabel)
+  if verbosity == NOISY_MODE or verbosity == VERY_NOISY_MODE:
+    hsv_base_image.show()
+  if is_dny_output == False:
+    with open(OUTPUT_DIR + "/" + output_prefix_name + output_suffix_name, "wb") as pointer_of_output_image_file:
+      hsv_base_image.save(pointer_of_output_image_file, 'PNG')
+
+##################################################
+#                   主処理                 
+##################################################
+def AnalyzeImage():
+  global is_running_process
+  global input_file_name
+  
+  try:
+    wait_controller = threading.Thread(target=WaitngAnimate)
+    wait_controller.start()
+    
+    with open(input_file_name, "rb") as pointer_of_input_image:
+      input_image = Image.open(pointer_of_input_image)
+    
+      hsv_image = input_image.convert("HSV")
+      hue_image, saturation_image, brightness_image = input_image.convert("HSV").split()
+      
+      if verbosity >= VERY_NOISY_MODE:
+        PrintDebugInfomation(input_image, hsv_image, hue_image, saturation_image, brightness_image)
+      
+      figure_hue = plt.figure(HUE_FIGURE_TITLE_NAME)
+      figure_saturation = plt.figure(SATURATION_FIGURE_TITLE_NAME)
+      figure_brightness = plt.figure(BRIGHTNESS_FIGURE_TITLE_NAME)
+      hue_plot = figure_hue.add_subplot(1,1,1)
+      saturation_plot = figure_saturation.add_subplot(1,1,1)
+      brightness_plot = figure_brightness.add_subplot(1,1,1)
+      
+      MakePlotFigure(hsv_base_image = hue_image,
+                    figure = hue_plot,
+                    plot_color = COLORS["blue"],
+                    figure_title = HUE_FIGURE_TITLE_NAME,
+                    xlabel = 'Value of Hue', ylabel = 'Frequent',
+                    equal_width_bins = equal_width,
+                    output_prefix_name = output_file_name,
+                    output_suffix_name = 'Image_Hue.png')
+      
+      MakePlotFigure(hsv_base_image = saturation_image,
+                    figure = saturation_plot,
+                    plot_color = COLORS["blue"],
+                    figure_title = SATURATION_FIGURE_TITLE_NAME,
+                    xlabel = 'Value of Saturation', ylabel = 'Frequent',
+                    equal_width_bins = equal_width,
+                    output_prefix_name = output_file_name,
+                    output_suffix_name = 'Image_Saturation.png')
+                    
+      MakePlotFigure(hsv_base_image = brightness_image,
+                    figure = brightness_plot,
+                    plot_color = COLORS["blue"],
+                    figure_title = BRIGHTNESS_FIGURE_TITLE_NAME,
+                    xlabel = 'Value of Brightness', ylabel = 'Frequent',
+                    equal_width_bins = equal_width,
+                    output_prefix_name = output_file_name,
+                    output_suffix_name = 'Image_Brightness.png')
+      
+      is_running_process=False
+      plt.show()
+      
+  except Exception as e:
+    wait_controller.terminate()
+    print("Unexpected error: " + str(e)) 
+    sys.exit(ERROR_EXIT)
+  except KeyboardInterrupt:
+    wait_controller.terminate()
+  
+  return NORMAL_EXIT
+
+##################################################
+#                    Main                 
+##################################################
+if __name__ == '__main__':
+  try:
+    DefineSystemArgumentsProcess()
+    AnalyzeImage()
+  except Exception as e:
+    print("Unexpected error: " + str(e)) 
+    sys.exit(ERROR_EXIT)
+  
+  sys.exit(NORMAL_EXIT)


### PR DESCRIPTION
# 目的

共有用の初期処理の開発

# 対応事項

- [x] `.gitignore` の更新
    - デフォルトの画像出力フォルダのファイルを無視 
- [x] `InitSetup.sh` の構築
    - 環境構築用のスクリプト（但し、POSIXかつbash環境のみ）
- [x] 利用に必要な依存ファイルを明記（Pipfile、Pipfile.lock）
- [x]  `pipenv sync` で環境構築用
- [x] 画像加工用スクリプト（main.py）
    - 今回主に作成したもの
- [x] 標準出力先確保用（output/.gitkeep）

## スクリプトの引数

``` bash
-- 必須引数
-f: 入力ファイルの決定
-- 任意引数
-h: ヘルプ表示
-e: グラフの幅を決定
-o: 加工後の画像ファイル名のprefixを設定
-d: 加工後の画像ファイルを表示しない（-vとの利用を想定）
-v: 詳細出力（-vと-vvが利用可能）
```
