### PR TITLE
Feat: グラフのX軸の最小値と最大値の固定 - 002

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,6 +47,8 @@ equal_width = DEFAULT_EQUAL_WIDTH_BINS
 is_dny_output = False
 use_interactive_mode = False
 verbosity = 0
+default_xlim_max = 255
+default_xlim_min = 0 
 
 NOMAL_MODE = 0
 NOISY_MODE = 1
@@ -173,6 +175,9 @@ def AnalyzeImage():
   global prefix_figure_title_name
   global use_interactive_mode
   
+  global default_xlim_max
+  global default_xlim_min
+  
   hue_figure_title_name_with_prefix = prefix_figure_title_name + HUE_FIGURE_TITLE_NAME
   saturation_figure_title_name_with_prefix = prefix_figure_title_name + SATURATION_FIGURE_TITLE_NAME
   brightness_figure_title_name_with_prefix = prefix_figure_title_name + BRIGHTNESS_FIGURE_TITLE_NAME
@@ -223,6 +228,10 @@ def AnalyzeImage():
                     equal_width_bins = equal_width,
                     output_prefix_name = output_file_name,
                     output_suffix_name = 'Image_Brightness.png')
+                    
+      hue_plot.set_xlim([default_xlim_min, default_xlim_max])
+      saturation_plot.set_xlim([default_xlim_min, default_xlim_max])
+      brightness_plot.set_xlim([default_xlim_min, default_xlim_max])
       
       figure_hue.savefig(OUTPUT_FIGURE_DIR + "/" + output_file_name + 'Image_Hue.png')
       figure_saturation.savefig(OUTPUT_FIGURE_DIR + "/" + output_file_name + 'Image_Saturation.png')

--- a/main.py
+++ b/main.py
@@ -229,9 +229,9 @@ def AnalyzeImage():
                     output_prefix_name = output_file_name,
                     output_suffix_name = 'Image_Brightness.png')
                     
-      hue_plot.set_xlim([default_xlim_min, default_xlim_max])
-      saturation_plot.set_xlim([default_xlim_min, default_xlim_max])
-      brightness_plot.set_xlim([default_xlim_min, default_xlim_max])
+      hue_plot.set_xlim(left=default_xlim_min, right=default_xlim_max)
+      saturation_plot.set_xlim(left=default_xlim_min, right=default_xlim_max)
+      brightness_plot.set_xlim(left=default_xlim_min, right=default_xlim_max)
       
       figure_hue.savefig(OUTPUT_FIGURE_DIR + "/" + output_file_name + 'Image_Hue.png')
       figure_saturation.savefig(OUTPUT_FIGURE_DIR + "/" + output_file_name + 'Image_Saturation.png')


### PR DESCRIPTION
## 目的

- 出力グラフのX軸の最小値と最大値の固定
    - 最小値を0、最大値を255に固定
         - ライブラリのPILの仕様により画素値が 0～255 で表現されるため

## 関連PR

- ren-8bit/HSVChecker#8

## 対応内容

- 主処理中に最大値と最小値を明示的に設定
- 実装方式が公式ドキュメントと異なっていたため修正

## 実現できること

1. X軸の余計なパディングの除去
    - 見た目の成型のみの効果 

## 参考文献

1. [(公式ドキュメント v3.5.0) matplotlib.axes.Axes.set_xlim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xlim.html)
 