### PR TITLE
図表の日本語化対応

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 matplotlib = "==3.5.0"
 numpy = "==1.22.0"
 pillow = "==8.4.0"
+japanize_matplotlib = "==1.1.3"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6b35248dcab8c0839ac0862d444d956bba538feb238d3763702ab0daecf66ac3"
+            "sha256": "4e30073d1f4260bba9eea20ec64e6b80522f442d60716b35316d463ea09344bd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,18 @@
         },
         "fonttools": {
             "hashes": [
-                "sha256:236b29aee6b113e8f7bee28779c1230a86ad2aac9a74a31b0aedf57e7dfb62a4",
-                "sha256:2df636a3f402ef14593c6811dac0609563b8c374bd7850e76919eb51ea205426"
+                "sha256:c0fdcfa8ceebd7c1b2021240bd46ef77aa8e7408cf10434be55df52384865f8e",
+                "sha256:f829c579a8678fa939a1d9e9894d01941db869de44390adb49ce67055a06cc2a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.31.2"
+            "version": "==4.33.3"
+        },
+        "japanize-matplotlib": {
+            "hashes": [
+                "sha256:e89e7d9e109820962650e59a130403b59b33915fde3871a265a5891d9bf5e079"
+            ],
+            "index": "pypi",
+            "version": "==1.1.3"
         },
         "kiwisolver": {
             "hashes": [
@@ -207,11 +214,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "python-dateutil": {
             "hashes": [
@@ -223,11 +230,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:8f4813dd6a4d6cc17bde85fb2e635fe19763f96efbb0ddf5575562e5ee0bc47a",
-                "sha256:c3d4e2ab578fbf83775755cd76dae73627915a22832cf4ea5de895978767833b"
+                "sha256:26ead7d1f93efc0f8c804d9fafafbe4a44b179580a7105754b245155f9af05a8",
+                "sha256:47c7b0c0f8fc10eec4cf1e71c6fdadf8decaa74ffa087e68cd1c20db7ad6a592"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==61.2.0"
+            "version": "==62.1.0"
         },
         "setuptools-scm": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# HSVChecker ver. 0.1.1
+# HSVChecker ver. 0.1.2
+
+## ライセンス上の重要な伝達事項
+
+利用の際には以下URLにあるライセンスに同意の上でご利用ください。
+
+同意が必要なライセンス:
+1. [IPAフォントライセンス v1.0](https://github.com/uehara1414/japanize-matplotlib/blob/master/japanize_matplotlib/fonts/IPA_Font_License_Agreement_v1.0.txt)
 
 ## スクリプトの概要
 
@@ -20,6 +27,18 @@ $ pipenv sync
 $ pipenv shell
 ```
 
+## 環境再構築方法
+
+``` bash
+# ローカル環境の全削除
+$ pipenv --rm
+# ローカル環境の再構築
+$ pipenv sync
+# 仮想環境に移行
+$ pipenv shell
+```
+
+
 ## スクリプトの使い方
 
 - 以下のコマンドを実行することで利用可能
@@ -39,6 +58,8 @@ $ python main.py -h
 - python: 3.9.1
 - matplotlib: 3.5.0
   - グラフ作成表示に利用
+- japanize-matplotlib: 1.1.3
+  - 日本語表示用のライブラリ
 - pillow: 8.4.0
   - 画像変換・加工に利用
 - NumPy: 1.22.0
@@ -46,7 +67,7 @@ $ python main.py -h
 
 ## 伝達事項
 
+- `japanize-matplotlib` を導入しましたため、日本語表示が可能になりました。
+  - ver. 0.1.1以前をご利用の方はコード更新と共に実行環境の更新が必要になります。
 - スクリプトの動作保障などは行っておりません。利用は自己責任の範囲で行ってください。
   - 不具合が起きないよう作りましたが何か見つけた場合はIssueにでも投げて頂ければ対応するかもしれません。
-- matplotlibに日本語フォントを組み込んでないので文字化け起こします。
-  - 入力することは可能ですが出力が豆腐に化けます。

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import time
 
 import numpy as np
 import matplotlib.pyplot as plt
+import japanize_matplotlib
 from PIL import Image
 
 ##################################################
@@ -33,13 +34,25 @@ DEFAULT_EQUAL_WIDTH_BINS = 255
 DEFAULT_NUMBER_OUTPUT_FORMAT='{:.1f}'
 WHITE_PADDING = "                                                "
 
-WINDOW_TITLE_PREFIX = "Figure of "
-WINDOW_TITLE_SUFFIX = " - Normalized"
-
-DEFAULT_FIGURE_TITLE_NAME = "Figure" + WINDOW_TITLE_SUFFIX
-HUE_FIGURE_TITLE_NAME = WINDOW_TITLE_PREFIX + "Hue" + WINDOW_TITLE_SUFFIX
-SATURATION_FIGURE_TITLE_NAME = WINDOW_TITLE_PREFIX + "Saturation" + WINDOW_TITLE_SUFFIX
-BRIGHTNESS_FIGURE_TITLE_NAME = WINDOW_TITLE_PREFIX + "Brightness" + WINDOW_TITLE_SUFFIX
+# グラフタイトル用の変数
+ENGLISH_WINDOW_TITLE_PREFIX = "Figure of "
+ENGLISH_WINDOW_TITLE_SUFFIX = " - Normalized"
+ENGLISH_DEFAULT_FIGURE_TITLE_NAME = "Figure" + ENGLISH_WINDOW_TITLE_SUFFIX
+JAPANESE_WINDOW_TITLE_PREFIX = "図表: "
+JAPANESE_WINDOW_TITLE_SUFFIX = " - 正規化済み"
+JAPANESE_DEFAULT_FIGURE_TITLE_NAME = "図表: " + JAPANESE_WINDOW_TITLE_SUFFIX
+HUE_FIGURE_TITLE_NAME = {
+  'english': ENGLISH_WINDOW_TITLE_PREFIX + "Hue" + ENGLISH_WINDOW_TITLE_SUFFIX,
+  'japanese': JAPANESE_WINDOW_TITLE_PREFIX + "色相" + JAPANESE_WINDOW_TITLE_SUFFIX
+}
+SATURATION_FIGURE_TITLE_NAME = {
+  'english': ENGLISH_WINDOW_TITLE_PREFIX + "Saturation" + ENGLISH_WINDOW_TITLE_SUFFIX,
+  'japanese': JAPANESE_WINDOW_TITLE_PREFIX + "彩度" + JAPANESE_WINDOW_TITLE_SUFFIX
+}
+BRIGHTNESS_FIGURE_TITLE_NAME = {
+  'english': ENGLISH_WINDOW_TITLE_PREFIX + "Brightness" + ENGLISH_WINDOW_TITLE_SUFFIX,
+  'japanese': JAPANESE_WINDOW_TITLE_PREFIX + "明度" + JAPANESE_WINDOW_TITLE_SUFFIX
+}
 
 input_file_name = ""
 output_file_name = ""
@@ -148,7 +161,7 @@ def DefineSystemArgumentsProcess():
   input_file_name = args.file
   if args.output_file != "":
     output_file_name = args.output_file + "_"
-    prefix_figure_title_name = '[ ' + args.output_file + ' ]: '
+    prefix_figure_title_name = '【 ' + args.output_file + ' 】 '
   equal_width = args.equal_width
   is_dny_output = args.is_dny_output
   use_interactive_mode = args.use_interactive_mode
@@ -231,9 +244,46 @@ def AnalyzeImage():
   global default_xlim_max
   global default_xlim_min
   
-  hue_figure_title_name_with_prefix = prefix_figure_title_name + HUE_FIGURE_TITLE_NAME
-  saturation_figure_title_name_with_prefix = prefix_figure_title_name + SATURATION_FIGURE_TITLE_NAME
-  brightness_figure_title_name_with_prefix = prefix_figure_title_name + BRIGHTNESS_FIGURE_TITLE_NAME
+  # グラフ表示の制御用変数
+  hue_figure_title_name_with_prefix = prefix_figure_title_name + HUE_FIGURE_TITLE_NAME['japanese']
+  saturation_figure_title_name_with_prefix = prefix_figure_title_name + SATURATION_FIGURE_TITLE_NAME['japanese']
+  brightness_figure_title_name_with_prefix = prefix_figure_title_name + BRIGHTNESS_FIGURE_TITLE_NAME['japanese']
+  xlabel_list = {
+    'hue_label': {
+      'english': 'Value of Hue',
+      'japanese': '色相の値'
+    },
+    'saturation_label': {
+      'english': 'Value of saturation',
+      'japanese': '彩度の値'
+    },
+    'brightness_label': {
+      'english': 'Value of brightness',
+      'japanese': '明度の値'
+    },
+  }
+  ylabel_list = {
+    'hue_label': {
+      'english': 'Frequent',
+      'japanese': '頻出度'
+    },
+    'saturation_label': {
+      'english': 'Frequent',
+      'japanese': '頻出度'
+    },
+    'brightness_label': {
+      'english': 'Frequent',
+      'japanese': '頻出度'
+    },
+  }
+  mean_label = {
+    'english': 'Mean',
+    'japanese': '平均値'
+  }
+  median_label = {
+    'english': 'Median',
+    'japanese': '中央値'
+  }
   
   try:
     wait_controller = multiprocessing.Process(target=WaitingAnimate, args=(sync_queue,))
@@ -274,7 +324,7 @@ def AnalyzeImage():
                     figure = hue_plot,
                     plot_color = COLORS["blue"],
                     figure_title = hue_figure_title_name_with_prefix,
-                    xlabel = 'Value of Hue', ylabel = 'Frequent',
+                    xlabel = xlabel_list['hue_label']['japanese'], ylabel = ylabel_list['hue_label']['japanese'],
                     equal_width_bins = equal_width,
                     output_prefix_name = output_file_name,
                     output_suffix_name = 'Image_Hue.png')
@@ -283,7 +333,7 @@ def AnalyzeImage():
                     figure = saturation_plot,
                     plot_color = COLORS["blue"],
                     figure_title = saturation_figure_title_name_with_prefix,
-                    xlabel = 'Value of Saturation', ylabel = 'Frequent',
+                    xlabel = xlabel_list['saturation_label']['japanese'], ylabel = ylabel_list['saturation_label']['japanese'],
                     equal_width_bins = equal_width,
                     output_prefix_name = output_file_name,
                     output_suffix_name = 'Image_Saturation.png')
@@ -292,7 +342,7 @@ def AnalyzeImage():
                     figure = brightness_plot,
                     plot_color = COLORS["blue"],
                     figure_title = brightness_figure_title_name_with_prefix,
-                    xlabel = 'Value of Brightness', ylabel = 'Frequent',
+                    xlabel = xlabel_list['brightness_label']['japanese'], ylabel = ylabel_list['brightness_label']['japanese'],
                     equal_width_bins = equal_width,
                     output_prefix_name = output_file_name,
                     output_suffix_name = 'Image_Brightness.png')
@@ -308,15 +358,15 @@ def AnalyzeImage():
       
       y_bottom, y_top = hue_plot.get_ylim()
       y_position = y_top * 0.98                   # 係数は暫定
-      hue_plot.text(DEFAULT_X_TEXT_POSITON, y_position, template_phrase_show_analytics_values.format('Mean', hue_mean, 'Median', hue_median), \
+      hue_plot.text(DEFAULT_X_TEXT_POSITON, y_position, template_phrase_show_analytics_values.format(mean_label['japanese'], hue_mean, median_label['japanese'], hue_median), \
                         fontsize=8,verticalalignment="top", backgroundcolor=DEFAULT_BACKGROUND_COLOR)
       y_bottom, y_top = saturation_plot.get_ylim()
       y_position = y_top * 0.98                   # 係数は暫定
-      saturation_plot.text(DEFAULT_X_TEXT_POSITON, y_position, template_phrase_show_analytics_values.format('Mean', saturation_mean, 'Median', saturation_median), \
+      saturation_plot.text(DEFAULT_X_TEXT_POSITON, y_position, template_phrase_show_analytics_values.format(mean_label['japanese'], saturation_mean, median_label['japanese'], saturation_median), \
                         fontsize=8,verticalalignment="top", backgroundcolor=DEFAULT_BACKGROUND_COLOR)
       y_bottom, y_top = brightness_plot.get_ylim()
       y_position = y_top * 0.98                   # 係数は暫定
-      brightness_plot.text(DEFAULT_X_TEXT_POSITON, y_position, template_phrase_show_analytics_values.format('Mean', brightness_mean, 'Median', brightness_median), \
+      brightness_plot.text(DEFAULT_X_TEXT_POSITON, y_position, template_phrase_show_analytics_values.format(mean_label['japanese'], brightness_mean, median_label['japanese'], brightness_median), \
                         fontsize=8,verticalalignment="top", backgroundcolor=DEFAULT_BACKGROUND_COLOR)
       
       figure_hue.savefig(OUTPUT_FIGURE_DIR + "/" + output_file_name + 'Image_Hue.png')


### PR DESCRIPTION
## 目的

- 図表を日本語表記を利用できるようにした

## 関連チケット

- ren-8bit/HSVChecker#14

## 対応内容

- `japanize_matplotlib` を利用して日本語対応のフォントを利用
    - 外部のライセンスにも依存するようになったため注意
- 図表の表現を日本語に切替
   - 内部データとしては英語は保持してあり切替は可能（切替機能は未実装）

## 実現できること

1. 日本語を利用しても文字化けが起きなくなった

## 参考文献

1. [(利用ライブラリ) japanize-matplotlib](https://pypi.org/project/japanize-matplotlib/)
 