### PR TITLE
暫定的なメモリリークへの対応

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import time
 import glob
 import csv
 import tracemalloc
+import gc
 
 import numpy as np
 import matplotlib
@@ -42,6 +43,7 @@ COLORS = {
 DEFAULT_EQUAL_WIDTH_BINS = 255
 DEFAULT_NUMBER_OUTPUT_FORMAT='{:.1f}'
 WHITE_PADDING = "                                                "
+BUFFER_POOL_SIZE = 10
 
 # グラフタイトル用の変数
 ENGLISH_WINDOW_TITLE_PREFIX = "Figure of "
@@ -476,6 +478,7 @@ if __name__ == '__main__':
       # Batch mode
       if input_file_name == "":
         print("Enter batch mode:")
+        loop_index = 0
         filter_pattern = re.compile(regex_file_name_pattern)
         
         for str_file_name in glob.iglob('input/**', recursive=True):
@@ -485,6 +488,14 @@ if __name__ == '__main__':
             
             if is_memory_trace_mode == True:
               memory_leak_checker.PrintCurrentMemoryStatus()
+            
+            # メモリ・リーク暫定対応
+            loop_index += 1
+            if (loop_index % BUFFER_POOL_SIZE) == 0:
+              gc.collect()                  # 効果が怪しいけど...
+              result_csv_file.flush()       # 応急退避
+              loop_index = 0
+          
         print("The process has been completed🎉")
       # Single file process mode
       else:

--- a/main.py
+++ b/main.py
@@ -13,6 +13,8 @@ import csv
 import tracemalloc
 
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')                 # お試し
 import matplotlib.pyplot as plt
 import japanize_matplotlib
 from PIL import Image


### PR DESCRIPTION
## 目的

メモリリークと思しき挙動を確認したため、その対応を行い処理が永続できるようにする。

## 対策

- [x] メモリリーク検知用の仕組みの導入
- [x] 途中処理されたCSVファイルの出力
- [x] 強制ガベージコレクション実行
- [x] `matplotlib` の処理方式変更

## 関連チケット

- ren-8bit/HSVChecker#19

## メモリリーク元の推測

- Matlab の変数が怪しいとみている
  - 根拠： ren-8bit/HSVChecker#19#issuecomment-1153207218
  - 対応方法： Matlabのメモリが処理とともに増加するため臨時的な対応を行う。
　　　　　 特にCSVの出力が途中で止まってしまうのでCSVに書きだした後に終了するようにする。

## 備忘録

- pythonの変数は関節参照を利用することでGCの明示的な対象にならない模様。
